### PR TITLE
Proposals for v0.1.3

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,11 @@
+### 2021-06-21 - v0.1.3 ###
+
+* fixed a warning in latextext.py
+  latextext.py:471: SyntaxWarning: "is not" with a literal. Did you mean "!="?
+    if self.options.math and latex_string[0] is not '$':
+
+* install.sh: now sets the extension path depending on the operating system
+  (Linux and Mac currently supported, more OSes can easily be added later)
 
 ### 2019-03-09 - v0.1.2 ###
 

--- a/extension/latextext.py
+++ b/extension/latextext.py
@@ -468,7 +468,7 @@ class SvgProcessor:
             if txt_empty:
                 log_debug("Empty text element, skipping...")
                 continue
-            if self.options.math and latex_string[0] is not '$':
+            if self.options.math and latex_string[0] != '$':
                 latex_string = '$' + latex_string + '$'
             log_debug(latex_string)
             rendergroup = lat2svg.render(latex_string, self.options.preamble, self.options.packages, self.options.fontsize, self.options.scale)

--- a/install.sh
+++ b/install.sh
@@ -3,6 +3,14 @@
 DEPENDENCIES=true
 GTK3=false
 
+OS=`uname -s`
+
+case $OS in
+  Linux*) EXTENSIONS_DIR=~/.config/inkscape/extensions/ ;;
+  Darwin*) EXTENSIONS_DIR=~/Library/Application\ Support/org.inkscape.Inkscape/config/inkscape/extensions/ ;;
+  *) echo "$OS unknown or not yet supported" 1>&2 ; exit 1 ;;
+esac
+
 echo -n "Check if Python LXML is available... "
 python -c "import lxml" 2> /dev/null
 if [ $? -ne 0 ]; then
@@ -27,15 +35,15 @@ else
     echo "OK"
 fi
 
-echo -n "Copying extension to ~/.config/inkscape/extensions/ ... "
+echo -n "Copying extension to $EXTENSIONS_DIR ... "
 
-cp extension/latextext.py ~/.config/inkscape/extensions/
+cp extension/latextext.py "$EXTENSIONS_DIR"
     
 if [ "$GTK3" = true ]; then
-    cp extension/latextext_gtk3.py ~/.config/inkscape/extensions/
-    cp extension/latextext_gtk3.inx ~/.config/inkscape/extensions/
+    cp extension/latextext_gtk3.py "$EXTENSIONS_DIR"
+    cp extension/latextext_gtk3.inx "$EXTENSIONS_DIR"
 else
-    cp extension/latextext.inx ~/.config/inkscape/extensions/
+    cp extension/latextext.inx "$EXTENSIONS_DIR"
 fi
 
 echo "done"


### PR DESCRIPTION
Greetings,

I tried your fork of LaTexText on a MacOS system with Python 3.8.3 and met a few issues for which I propose minor fixes:

- install.sh: doesn't work on Mac systems because the path to Inkscape's extensions is different from Linux. I propose a fix with a detection of the OS and proper set up of the extensions directory depending on the outcome
- extension/latextext.py: fixed a syntax warning ("is not" was used with a literal)